### PR TITLE
Remove hard-coded Jira URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# JIRAtime
+# JiraTime
 
 ![Tag and Release](https://github.com/smlx/jiratime/workflows/Tag%20and%20Release/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/smlx/jiratime/badge.svg?branch=main)](https://coveralls.io/github/smlx/jiratime?branch=main)
 
-`jiratime` makes it easy to submit timesheets to JIRA quickly from the command line.
+`jiratime` makes it easy to submit timesheets to Jira quickly from the command line.
 It is designed for use with timesheets logged in (neo)vim.
 
 ## Get it
@@ -62,7 +62,7 @@ ever stop?
 
 #### Features
 
-Timesheet entries are converted to JIRA worklog records.
+Timesheet entries are converted to Jira worklog records.
 Each begins with a duration written as a time range in 24-hour format.
 
 ```
@@ -88,7 +88,7 @@ ABC-987
 lunch
 ```
 
-JIRA issues may be identified explicitly by putting the name of the issue at the start of the first line of the comment body.
+Jira issues may be identified explicitly by putting the name of the issue at the start of the first line of the comment body.
 
 ```
 0945-1100
@@ -99,7 +99,7 @@ will the meetings
 ever stop?
 ```
 
-JIRA issues may be identified implicitly by matching the first line against a configured regular expression (see Configuration below).
+Jira issues may be identified implicitly by matching the first line against a configured regular expression (see Configuration below).
 
 ```
 0900-0945
@@ -113,7 +113,7 @@ Timesheet entries may be ignored by matching the first line against a configured
 lunch
 ```
 
-Implicitly matched issues can have a default comment configured which will be automatically added to the JIRA worklog record if no comment is defined in the timesheet.
+Implicitly matched issues can have a default comment configured which will be automatically added to the Jira worklog record if no comment is defined in the timesheet.
 
 ```
 1100-1200
@@ -124,7 +124,7 @@ admin
 
 `jiratime` tries hard to submit timesheets atomically.
 That is, either all worklog records are submitted, or none are.
-It does this by checking that all issues identified are valid JIRA issues before submitting any worklogs.
+It does this by checking that all issues identified are valid Jira issues before submitting any worklogs.
 
 `jiratime` exits with a return code of zero and no output on success.
 On failure it will exit with a non-zero return code and a message on standard error.
@@ -133,10 +133,10 @@ On failure it will exit with a non-zero return code and a message on standard er
 
 ### Authorization Setup
 
-`jiratime` authenticates to JIRA as an OAuth2, client.
+`jiratime` authenticates to Jira as an OAuth2, client.
 This requires a one-time initial setup.
 
-#### Configure `jiratime` app in JIRA cloud
+#### Configure `jiratime` app in Jira cloud
 
 1. Visit Atlassian's developer console here, and log in: https://developer.atlassian.com/console/myapps/
 2. Create a new "OAuth 2.0 integration".

--- a/cmd/jiratime/submit.go
+++ b/cmd/jiratime/submit.go
@@ -13,7 +13,7 @@ import (
 // SubmitCmd represents the default `submit` command.
 type SubmitCmd struct {
 	DayOffset int  `kong:"short='d',help='submit time for a day at some offset to today'"`
-	DryRun    bool `kong:"help='read-only mode; do not actually make any changes in JIRA'"`
+	DryRun    bool `kong:"help='read-only mode; do not actually make any changes in Jira'"`
 }
 
 // Run the Submit command.

--- a/cmd/jiratime/submit.go
+++ b/cmd/jiratime/submit.go
@@ -33,7 +33,9 @@ func (cmd *SubmitCmd) Run() error {
 		return fmt.Errorf("couldn't parse worklogs: %v", err)
 	}
 	// push the worklogs into jira
-	if err = client.UploadWorklogs(ctx, worklogs, cmd.DayOffset, cmd.DryRun); err != nil {
+	err = client.UploadWorklogs(ctx, conf.JiraURL, worklogs, cmd.DayOffset,
+		cmd.DryRun)
+	if err != nil {
 		return fmt.Errorf("couldn't upload worklogs: %v", err)
 	}
 	return nil

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// GetOAuth2Config gets an OAuth2 Config object configured for Atlassian JIRA
+// GetOAuth2Config gets an OAuth2 Config object configured for Atlassian Jira
 // Cloud.
 func GetOAuth2Config(auth *config.OAuth2) *oauth2.Config {
 	return &oauth2.Config{

--- a/internal/client/upload.go
+++ b/internal/client/upload.go
@@ -13,7 +13,7 @@ import (
 
 // UploadWorklogs uploads the given worklogs to JIRA, with the
 // given day offset (e.g. -1 == yesterday).
-func UploadWorklogs(ctx context.Context,
+func UploadWorklogs(ctx context.Context, jiraURL string,
 	issueWorklogs map[string][]parse.Worklog, dayOffset int, dryRun bool) error {
 	// load the auth config to get the oauth2 token
 	auth, err := config.ReadAuth()
@@ -32,7 +32,7 @@ func UploadWorklogs(ctx context.Context,
 	oauth2Conf := GetOAuth2Config(auth)
 	httpClient := oauth2Conf.Client(ctx, auth.Token)
 	// wrap this http client in a jira client via jira.NewClient
-	c, err := jira.NewClient(httpClient, "https://amazeeio.atlassian.net/")
+	c, err := jira.NewClient(httpClient, jiraURL)
 	if err != nil {
 		return fmt.Errorf("couldn't get new JIRA client: %v", err)
 	}

--- a/internal/client/upload.go
+++ b/internal/client/upload.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smlx/jiratime/internal/parse"
 )
 
-// UploadWorklogs uploads the given worklogs to JIRA, with the
+// UploadWorklogs uploads the given worklogs to Jira, with the
 // given day offset (e.g. -1 == yesterday).
 func UploadWorklogs(ctx context.Context, jiraURL string,
 	issueWorklogs map[string][]parse.Worklog, dayOffset int, dryRun bool) error {
@@ -34,13 +34,13 @@ func UploadWorklogs(ctx context.Context, jiraURL string,
 	// wrap this http client in a jira client via jira.NewClient
 	c, err := jira.NewClient(httpClient, jiraURL)
 	if err != nil {
-		return fmt.Errorf("couldn't get new JIRA client: %v", err)
+		return fmt.Errorf("couldn't get new Jira client: %v", err)
 	}
 	// check that all the issues in worklogs exist
 	for issue := range issueWorklogs {
 		_, _, err := c.Issue.GetWithContext(ctx, issue, nil)
 		if err != nil {
-			return fmt.Errorf("couldn't get JIRA issue %s: %v", issue, err)
+			return fmt.Errorf("couldn't get Jira issue %s: %v", issue, err)
 		}
 	}
 	if dryRun {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 
 const pathSuffix = "jiratime/config.yml"
 
-// Issue represents the list of known JIRA issues.
+// Issue represents the list of known Jira issues.
 type Issue struct {
 	ID             string   `json:"id"`
 	Regexes        []Regexp `json:"regexes"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,9 @@ type Issue struct {
 
 // Config represents the structure of the config file.
 type Config struct {
-	Issues []Issue  `json:"issues"`
-	Ignore []Regexp `json:"ignore"`
+	JiraURL string   `json:"jiraURL"`
+	Issues  []Issue  `json:"issues"`
+	Ignore  []Regexp `json:"ignore"`
 }
 
 // Read the config file.

--- a/internal/parse/fsm.go
+++ b/internal/parse/fsm.go
@@ -40,7 +40,7 @@ type TimesheetParser struct {
 	comment []string
 	// defaultComment is appended to comment if comment is otherwise empty
 	defaultComment string
-	// issue is the JIRA issue name e.g. XYZ-123
+	// issue is the Jira issue name e.g. XYZ-123
 	issue string
 }
 

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -49,7 +49,7 @@ func parseTimeRange(t string) (time.Time, time.Duration, error) {
 }
 
 // getImplicitIssue attempts to match a given string against a list of regexes
-// configured for a JIRA issue. It returns an error if no match can be found.
+// configured for a Jira issue. It returns an error if no match can be found.
 func getImplicitIssue(line string, c *config.Config) (string, string, string, error) {
 	for _, issue := range c.Issues {
 		for _, r := range issue.Regexes {


### PR DESCRIPTION
This makes it possible to use `jiratime` for any cloud instance of Jira.