### PR TITLE
fix: do not purge client ID from auth.yml

### DIFF
--- a/cmd/jiratime/authorize.go
+++ b/cmd/jiratime/authorize.go
@@ -97,9 +97,8 @@ func (cmd *AuthorizeCmd) Run() error {
 		log.Fatal(err)
 	}
 	auth.Token = tok
-	// purge the ClientID and Secret before writing, since these are not required
-	// once a token is obtained
-	auth.ClientID = ""
+	// purge the client secret before writing, since it is not required once a
+	// token is obtained
 	auth.Secret = ""
 	if err = config.WriteAuth(auth); err != nil {
 		return fmt.Errorf("couldn't write config: %v", err)

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -18,7 +18,7 @@ type Auth struct {
 
 // OAuth2 is a config entry containing oauth2 secrets
 type OAuth2 struct {
-	ClientID string        `json:"clientID,omitempty"`
+	ClientID string        `json:"clientID"`
 	Secret   string        `json:"secret,omitempty"`
 	Token    *oauth2.Token `json:"token"`
 }


### PR DESCRIPTION
Client ID is a required field. So keep that and just purge the secret.

This fixes an issue where the Atlassian Jira API returned an error like:
```
{"error":"invalid_request","error_description":"client_id may not be blank"}
```
