### PR TITLE
chore: disable codeql schedule

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -7,8 +7,6 @@ on:
     # The branches below must be a subset of the branches above
     branches:
     - main
-  schedule:
-  - cron: '29 15 * * 1'
 
 jobs:
   analyze:
@@ -17,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language:
+        - go
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This is not useful. Just scan on merge to main.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
