### PR TITLE
fix: revert the "strip secret" change

### DIFF
--- a/cmd/jiratime/authorize.go
+++ b/cmd/jiratime/authorize.go
@@ -97,9 +97,6 @@ func (cmd *AuthorizeCmd) Run() error {
 		log.Fatal(err)
 	}
 	auth.Token = tok
-	// purge the client secret before writing, since it is not required once a
-	// token is obtained
-	auth.Secret = ""
 	if err = config.WriteAuth(auth); err != nil {
 		return fmt.Errorf("couldn't write config: %v", err)
 	}

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -19,7 +19,7 @@ type Auth struct {
 // OAuth2 is a config entry containing oauth2 secrets
 type OAuth2 struct {
 	ClientID string        `json:"clientID"`
-	Secret   string        `json:"secret,omitempty"`
+	Secret   string        `json:"secret"`
 	Token    *oauth2.Token `json:"token"`
 }
 


### PR DESCRIPTION
The secret is required to refresh the token as per https://datatracker.ietf.org/doc/html/rfc6749#section-6

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
