### PR TITLE
feat: revert to classic scopes

### DIFF
--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -1,3 +1,4 @@
+// Package client implements a JIRA REST API client.
 package client
 
 import (
@@ -14,18 +15,8 @@ func GetOAuth2Config(auth *config.OAuth2) *oauth2.Config {
 		// offline_access requests a refresh token
 		Scopes: []string{
 			"offline_access",
-			"read:avatar:jira",
-			"read:field-configuration:jira",
-			"read:group:jira",
-			"read:issue-worklog.property:jira",
-			"read:issue-worklog:jira",
-			"read:issue.transition:jira",
-			"read:project-role:jira",
-			"read:status:jira",
-			"read:user:jira",
-			"write:issue-worklog.property:jira",
-			"write:issue-worklog:jira",
-			"write:issue.time-tracking:jira",
+			"read:jira-work",
+			"write:jira-work",
 		},
 		Endpoint: oauth2.Endpoint{
 			TokenURL: "https://auth.atlassian.com/oauth/token",

--- a/internal/client/upload.go
+++ b/internal/client/upload.go
@@ -40,7 +40,7 @@ func UploadWorklogs(ctx context.Context, jiraURL string,
 	}
 	// check that all the issues in worklogs exist
 	for issue := range issueWorklogs {
-		_, _, err := c.Issue.GetTransitionsWithContext(ctx, issue)
+		_, _, err := c.Issue.GetWithContext(ctx, issue, nil)
 		if err != nil {
 			return fmt.Errorf("couldn't get Jira issue %s: %v", issue, err)
 		}


### PR DESCRIPTION
Atlassian now recommends to revert to use their classic OAuth2 scopes.

I've also seen some weird JIRA API issues in the last couple of days that this seems to help with (maybe??).

This change requires you to re-auth to get a new token with the new (old) scopes.

See https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/#setting-your-app-s-scopes
