### PR TITLE
Fix auth errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ generate: mod-tidy
 
 .PHONY: build
 build:
-	GOVERSION=$$(go version) goreleaser build  --rm-dist --debug --snapshot
+	GOVERSION=$$(go version) goreleaser build --clean --debug --snapshot

--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ Unfortunately there is no transactional batch API for Jira worklogs.
 `jiratime` exits with a return code of zero and no output on success.
 On failure it will exit with a non-zero return code and a message on standard error.
 
-## Usage
+## Authorization Setup
 
-### Authorization Setup
+`jiratime` authentication requires a one-time initial setup.
 
-`jiratime` authenticates to Jira as an OAuth2 client.
-This requires a one-time initial setup.
+`jiratime` can authenticate using OAuth2 (more secure, more complex setup, the default), or using an API Key and HTTP Basic Auth (less secure, but simpler).
+
+### OAuth2
 
 #### Configure jiratime app in Jira cloud
 
@@ -150,18 +151,8 @@ This requires a one-time initial setup.
 
 1. Select "Permissions", then "Add", and "Configure" the "Jira platform REST API".
 2. Ensure these scopes are selected:
-   * `read:avatar:jira`
-   * `read:field-configuration:jira`
-   * `read:group:jira`
-   * `read:issue-worklog.property:jira`
-   * `read:issue-worklog:jira`
-   * `read:issue.transition:jira`
-   * `read:project-role:jira`
-   * `read:status:jira`
-   * `read:user:jira`
-   * `write:issue-worklog.property:jira`
-   * `write:issue-worklog:jira`
-   * `write:issue.time-tracking:jira`
+   * `read:jira-work`
+   * `write:jira-work`
 
 ##### Authorization callback URL
 
@@ -177,7 +168,7 @@ This requires a one-time initial setup.
 
 Create `$XDG_CONFIG_HOME/jiratime/auth.yml` and add your app credentials:
 
-```
+```yaml
 oauth2:
   clientID: chiYahchob7xoThahvohH5quae6Di0Ee
   secret: HxHOiN3bD5l93X3qugp9bHI8EKEJ7xVV4vcj6tG3vr7GFqxtxruMrkLcgtZAOPrZ
@@ -191,6 +182,21 @@ Authorization successful. You may now close this page.
 ```
 
 `$XDG_CONFIG_HOME/jiratime/auth.yml` now contains a token that `jiratime` will use and automatically refresh as required.
+
+### Basic Auth
+
+1. Visit Atlassian's [developer console](https://developer.atlassian.com/console/myapps/), and log in.
+2. Create a new API Key.
+3. Add the credentials to `$XDG_CONFIG_HOME/jiratime/basicauth.yml`.
+
+Example:
+
+```yaml
+user: my.name@example.com
+apiKey: SZ8411BnS9dKw2FDArWAe9eYiToNTx6ugtCzR2UTtaSFmXnw16bYcBuiLFYuqSffnFEzdXti8HcVRWPaLjPxFaOx7KVlckD2amFoxiiwK2hTBlfYU62CrJJ3VfZprwf3
+```
+
+## Usage
 
 ### Timesheet submission
 

--- a/cmd/jiratime/submit.go
+++ b/cmd/jiratime/submit.go
@@ -14,6 +14,7 @@ import (
 type SubmitCmd struct {
 	DayOffset int  `kong:"short='d',help='submit time for a day at some offset to today'"`
 	DryRun    bool `kong:"help='read-only mode; do not actually make any changes in Jira'"`
+	BasicAuth bool `kong:"help='use basic auth instead of OAuth2'"`
 }
 
 // Run the Submit command.
@@ -34,7 +35,7 @@ func (cmd *SubmitCmd) Run() error {
 	}
 	// push the worklogs into jira
 	err = client.UploadWorklogs(ctx, conf.JiraURL, worklogs, cmd.DayOffset,
-		cmd.DryRun)
+		cmd.DryRun, cmd.BasicAuth)
 	if err != nil {
 		return fmt.Errorf("couldn't upload worklogs: %v", err)
 	}

--- a/internal/client/upload.go
+++ b/internal/client/upload.go
@@ -15,21 +15,47 @@ import (
 
 const requestRetries = 4
 
-// UploadWorklogs uploads the given worklogs to Jira, with the
-// given day offset (e.g. -1 == yesterday).
-func UploadWorklogs(ctx context.Context, jiraURL string,
-	issueWorklogs map[string][]parse.Worklog, dayOffset int, dryRun bool) error {
+// authenticatedRoundTripper implements the http.RoundTripper interface
+type authenticatedRoundTripper struct {
+	username string
+	password string
+}
+
+// RoundTrip sets the basic authentication header and then handles the request
+// using the http.DefaultTransport.
+func (art *authenticatedRoundTripper) RoundTrip(
+	req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(art.username, art.password)
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func newBasicAuthHTTPClient() (*http.Client, error) {
+	basic, err := config.ReadBasicAuth()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read basic auth: %v", err)
+	}
+	// construct http.Client with automatic basic auth
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &authenticatedRoundTripper{
+			username: basic.User,
+			password: basic.APIKey,
+		},
+	}, nil
+}
+
+func newOAuth2HTTPClient(ctx context.Context) (*http.Client, oauth2.TokenSource, *config.OAuth2, error) {
 	// load the auth config to get the oauth2 token
 	auth, err := config.ReadAuth()
 	if err != nil {
-		return fmt.Errorf("couldn't load auth config: %v", err)
+		return nil, nil, nil, fmt.Errorf("couldn't load auth config: %v", err)
 	}
 	// sanity check that there is an access_token and refresh_token
 	if auth == nil {
-		return fmt.Errorf("couldn't find oauth2 configuration")
+		return nil, nil, nil, fmt.Errorf("couldn't find oauth2 configuration")
 	}
 	if auth.Token.AccessToken == "" || auth.Token.RefreshToken == "" {
-		return fmt.Errorf("missing access_token or refresh_token." +
+		return nil, nil, nil, fmt.Errorf("missing access_token or refresh_token." +
 			" Please run `authorize` to refresh tokens")
 	}
 	// create an http client using the oauth2 token. this will auto-refresh the
@@ -37,37 +63,70 @@ func UploadWorklogs(ctx context.Context, jiraURL string,
 	oauth2Conf := GetOAuth2Config(auth)
 	tokenSource := oauth2Conf.TokenSource(ctx, auth.Token)
 	httpClient := oauth2.NewClient(ctx, tokenSource)
+	return httpClient, tokenSource, auth, nil
+}
+
+// UploadWorklogs uploads the given worklogs to Jira, with the
+// given day offset (e.g. -1 == yesterday).
+func UploadWorklogs(ctx context.Context, jiraURL string,
+	issueWorklogs map[string][]parse.Worklog, dayOffset int, dryRun bool,
+	basicAuth bool) error {
+	var httpClient *http.Client
+	var err error
+	var tokenSource oauth2.TokenSource
+	var auth *config.OAuth2
+	if basicAuth {
+		httpClient, err = newBasicAuthHTTPClient()
+		if err != nil {
+			return fmt.Errorf("couldn't construct basic auth HTTP client: %v", err)
+		}
+	} else {
+		httpClient, tokenSource, auth, err = newOAuth2HTTPClient(ctx)
+		if err != nil {
+			return fmt.Errorf("couldn't construct OAuth2 HTTP client: %v", err)
+		}
+	}
 	// wrap this http client in a jira client via jira.NewClient
 	c, err := jira.NewClient(httpClient, jiraURL)
 	if err != nil {
 		return fmt.Errorf("couldn't get new Jira client: %v", err)
 	}
 	// check that all the issues in worklogs exist
+	var success bool
 	for issue := range issueWorklogs {
-	retryGetIssue:
+		success = false
+		var err error
+		var response *jira.Response
 		for i := 0; i < requestRetries; i++ {
-			_, response, err := c.Issue.GetWithContext(ctx, issue, nil)
+			_, response, err = c.Issue.GetWithContext(ctx, issue, nil)
 			if err == nil {
-				break retryGetIssue
+				success = true
+				break // successful get
 			}
-			if response.StatusCode == http.StatusUnauthorized {
+			if response != nil && response.StatusCode == http.StatusUnauthorized {
 				continue
 			}
 			return fmt.Errorf("couldn't get Jira issue %s: %v", issue, err)
 		}
+		if !success {
+			return fmt.Errorf("couldn't get Jira issue %s after %d retries: %v",
+				issue, requestRetries, err)
+		}
 	}
-	// persist the token, as Atlassian rotates refresh tokens
-	newTok, err := tokenSource.Token()
-	if err != nil {
-		return fmt.Errorf("couldn't get Token from oauth2.TokenSource: %v", err)
-	}
-	err = config.WriteAuth(&config.OAuth2{
-		ClientID: auth.ClientID,
-		Secret:   auth.Secret,
-		Token:    newTok,
-	})
-	if err != nil {
-		return fmt.Errorf("couldn't persist new token: %v", err)
+	if !basicAuth {
+		// persist the token, as Atlassian rotates refresh tokens
+		newTok, err := tokenSource.Token()
+		if err != nil {
+			return fmt.Errorf("couldn't get Token from oauth2.TokenSource: %v", err)
+		}
+		err = config.WriteAuth(&config.OAuth2{
+			ClientID: auth.ClientID,
+			Secret:   auth.Secret,
+			Token:    newTok,
+		})
+		if err != nil {
+			return fmt.Errorf("couldn't persist new token: %v", err)
+		}
 	}
 	// exit early in dry-run mode
 	if dryRun {

--- a/internal/config/basicauth.go
+++ b/internal/config/basicauth.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/adrg/xdg"
+	"sigs.k8s.io/yaml"
+)
+
+const basicAuthPathSuffix = "jiratime/basicauth.yml"
+
+// BasicAuth represents the structure of the auth.yml
+type BasicAuth struct {
+	User   string `json:"user"`
+	APIKey string `json:"apiKey"`
+}
+
+// ReadBasicAuth the config file.
+func ReadBasicAuth() (*BasicAuth, error) {
+	path, err := xdg.ConfigFile(basicAuthPathSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get path to basicAuth config file: %v", err)
+	}
+	y, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read basicAuth config file: %v", err)
+	}
+	var a BasicAuth
+	if err = yaml.Unmarshal(y, &a); err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal basicAuth config: %v", err)
+	}
+	return &a, nil
+}
+
+// WriteBasicAuth persists the given Config to the given path.
+func WriteBasicAuth(a *BasicAuth) error {
+	path, err := xdg.ConfigFile(basicAuthPathSuffix)
+	if err != nil {
+		return fmt.Errorf("couldn't get path to basicAuth config file: %v", err)
+	}
+	confBytes, err := yaml.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("couldn't marshal basicAuth config: %v", err)
+	}
+	if err = os.WriteFile(path, confBytes, 0600); err != nil {
+		return fmt.Errorf("couldn't write basicAuth config file: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Atlassian's API recently started throwing errors for OAuth2 client token auth. The errors are sporadic but annoying. For example, sometimes the exact same request will get a 401 but if retried immediately will work.

To work around this breakage this PR adds:
a) Retries on auth errors.
b) Support for HTTP basic auth which seems to be less affected by the authentication issues.