### PR TITLE
feat: dump worklog records

### DIFF
--- a/cmd/jiratime/dumpworklogs.go
+++ b/cmd/jiratime/dumpworklogs.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/smlx/jiratime/internal/client"
+	"github.com/smlx/jiratime/internal/config"
+	"golang.org/x/exp/slog"
+)
+
+// DumpWorklogsCmd represents the `dump-worklogs` command.
+type DumpWorklogsCmd struct {
+	Since         time.Time     `kong:"required,help='time from which the worklogs should be dumped'"`
+	Timeout       time.Duration `kong:"default=1h,help='maximum duration allowed for the command to return'"`
+	WorklogAuthor string        `kong:"required,help='worklog author name'"`
+	BasicAuth     bool          `kong:"help='use basic auth instead of OAuth2'"`
+}
+
+// Run the DumpWorklogs command.
+func (cmd *DumpWorklogsCmd) Run() error {
+	// global timeout of 60 seconds
+	ctx, cancel := getContext(cmd.Timeout)
+	defer cancel()
+	// read config file
+	conf, err := config.Read()
+	if err != nil {
+		return fmt.Errorf("couldn't load config: %v", err)
+	}
+	level := slog.LevelVar{}
+	level.Set(slog.LevelDebug)
+	log := slog.New(
+		slog.HandlerOptions{
+			AddSource: true,
+			Level:     &level,
+		}.NewJSONHandler(os.Stderr))
+	// get the worklogs
+	worklogs, err := client.Worklogs(ctx, log, conf.JiraURL, cmd.Since,
+		cmd.WorklogAuthor, cmd.BasicAuth)
+	if err != nil {
+		return fmt.Errorf("couldn't dump worklogs: %v", err)
+	}
+	data, err := json.Marshal(worklogs)
+	if err != nil {
+		return fmt.Errorf("couldn't marshal worklogs: %v", err)
+	}
+	_, err = fmt.Println(string(data))
+	return err
+}

--- a/cmd/jiratime/main.go
+++ b/cmd/jiratime/main.go
@@ -1,3 +1,4 @@
+// Package main implements the command-line interface to jiratime.
 package main
 
 import (
@@ -12,9 +13,10 @@ import (
 
 // CLI represents the command-line interface.
 type CLI struct {
-	Submit    SubmitCmd    `kong:"cmd,default=1,help='(default) Submit times'"`
-	Authorize AuthorizeCmd `kong:"cmd,aliases='auth',help='Get OAuth2 client token'"`
-	Version   VersionCmd   `kong:"cmd,help='Print version information'"`
+	Submit       SubmitCmd       `kong:"cmd,default=1,help='(default) Submit times'"`
+	Authorize    AuthorizeCmd    `kong:"cmd,aliases='auth',help='Get OAuth2 client token'"`
+	DumpWorklogs DumpWorklogsCmd `kong:"cmd,help='Dump Worklog records in JSON format'"`
+	Version      VersionCmd      `kong:"cmd,help='Print version information'"`
 }
 
 // getContext starts a goroutine to handle ^C gracefully, and returns a

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v0.7.1
 	github.com/andygrunwald/go-jira v1.16.0
 	github.com/smlx/fsm v0.2.1
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/oauth2 v0.7.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=

--- a/internal/client/dump.go
+++ b/internal/client/dump.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"golang.org/x/exp/slog"
+)
+
+// getAllIssues returns all the issues by automatically paging through results.
+func getAllIssues(ctx context.Context, c *jira.Client,
+	search string) ([]jira.Issue, error) {
+	last := 0
+	var issues []jira.Issue
+	for {
+		opt := &jira.SearchOptions{
+			MaxResults: 1000, // max 1000
+			StartAt:    last,
+			Fields:     []string{"id", "key"},
+		}
+		chunk, resp, err := c.Issue.SearchWithContext(ctx, search, opt)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't search: %v", err)
+		}
+		total := resp.Total
+		issues = append(issues, chunk...)
+		last = resp.StartAt + len(chunk)
+		if last >= total {
+			return issues, nil
+		}
+	}
+}
+
+type worklogOpts struct {
+	jira.SearchOptions
+	StartedAfter int64 `url:"startedAfter,omitempty"`
+}
+
+// getWorklogRecords returns all worklogs where the author is the given user
+// on the given issue.
+func getWorklogRecords(ctx context.Context, c *jira.Client,
+	issueID, authorName string, since time.Time) ([]jira.WorklogRecord, error) {
+	last := 0
+	var wlrs []jira.WorklogRecord
+	for {
+		opt := worklogOpts{
+			SearchOptions: jira.SearchOptions{
+				MaxResults: 5000, // max 5000
+				StartAt:    last,
+			},
+			StartedAfter: since.UnixMilli(),
+		}
+		worklog, resp, err := c.Issue.GetWorklogsWithContext(ctx, issueID,
+			jira.WithQueryOptions(&opt))
+		if err != nil {
+			return nil, fmt.Errorf("couldn't search: %v", err)
+		}
+		total := resp.Total
+		// filter the worklog records by author
+		for _, wlr := range worklog.Worklogs {
+			if wlr.Author.DisplayName == authorName {
+				wlrs = append(wlrs, wlr)
+			}
+		}
+		last = resp.StartAt + len(worklog.Worklogs)
+		// return if we have paged through all records
+		if last >= total {
+			return wlrs, nil
+		}
+	}
+}
+
+// Worklogs returns the worklogs since the given time.
+func Worklogs(ctx context.Context, log *slog.Logger, jiraURL string,
+	since time.Time, authorName string,
+	basicAuth bool) (map[string][]jira.WorklogRecord, error) {
+	var httpClient *http.Client
+	var err error
+	httpClient, err = newBasicAuthHTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"couldn't construct basic auth HTTP client (required for worklogs): %v", err)
+	}
+	// wrap this http client in a jira client via jira.NewClient
+	c, err := jira.NewClient(httpClient, jiraURL)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get new Jira client: %v", err)
+	}
+	// get all the issues with a worklog by the author
+	issues, err := getAllIssues(ctx, c,
+		fmt.Sprintf(`worklogAuthor = "%s" AND worklogDate >= "%s"`,
+			authorName, since.Format("2006-01-02")))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get issues: %v", err)
+	}
+	log.InfoCtx(ctx, "found issues", slog.Int("issueCount", len(issues)))
+	// iterate through the issues getting all the associated worklogs
+	worklogs := map[string][]jira.WorklogRecord{}
+	for _, issue := range issues {
+		wlrs, err := getWorklogRecords(ctx, c, issue.Key, authorName, since)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't get worklogs: %v", err)
+		}
+		log.InfoCtx(ctx, "found worklog records",
+			slog.String("issue", issue.Key),
+			slog.Int("worklogRecordCount", len(wlrs)))
+		worklogs[issue.Key] = wlrs
+	}
+	return worklogs, nil
+}


### PR DESCRIPTION
Add a new subcommand allowing dumping of worklog records for a given author since a given date in JSON format.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
