### PR TITLE
feat: add option to round issues to 15 minutes

### DIFF
--- a/cmd/jiratime/submit.go
+++ b/cmd/jiratime/submit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smlx/jiratime/internal/client"
 	"github.com/smlx/jiratime/internal/config"
 	"github.com/smlx/jiratime/internal/parse"
+	"github.com/smlx/jiratime/internal/process"
 )
 
 // SubmitCmd represents the default `submit` command.
@@ -33,6 +34,8 @@ func (cmd *SubmitCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("couldn't parse worklogs: %v", err)
 	}
+	// process the worklogs to meet organisational policy
+	process.RoundWorklogs(worklogs, conf.RoundIssues)
 	// push the worklogs into jira
 	err = client.UploadWorklogs(ctx, conf.JiraURL, worklogs, cmd.DayOffset,
 		cmd.DryRun, cmd.BasicAuth)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/alecthomas/assert v1.0.0
+	github.com/alecthomas/assert/v2 v2.1.0
 	github.com/alecthomas/kong v0.7.1
 	github.com/andygrunwald/go-jira v1.16.0
 	github.com/smlx/fsm v0.2.1
@@ -20,6 +21,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E
 github.com/alecthomas/assert v1.0.0 h1:3XmGh/PSuLzDbK3W2gUbRXwgW5lqPkuqvRgeQ30FI5o=
 github.com/alecthomas/assert v1.0.0/go.mod h1:va/d2JC+M7F6s+80kl/R3G7FUiW6JzUO+hPhLyJ36ZY=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
+github.com/alecthomas/assert/v2 v2.1.0/go.mod h1:b/+1DI2Q6NckYi+3mXyH3wFb8qG37K/DuK80n7WefXA=
 github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrDUk=
 github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
 github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4=
@@ -29,6 +30,7 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config implements configuration file handling.
 package config
 
 import (
@@ -19,9 +20,10 @@ type Issue struct {
 
 // Config represents the structure of the config file.
 type Config struct {
-	JiraURL string   `json:"jiraURL"`
-	Issues  []Issue  `json:"issues"`
-	Ignore  []Regexp `json:"ignore"`
+	JiraURL     string   `json:"jiraURL"`
+	Issues      []Issue  `json:"issues"`
+	Ignore      []Regexp `json:"ignore"`
+	RoundIssues []Regexp `json:"roundIssues"`
 }
 
 // Read the config file.

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -1,0 +1,53 @@
+// Package process performs post-processing on parsed worklogs.
+package process
+
+import (
+	"time"
+
+	"github.com/smlx/jiratime/internal/config"
+	"github.com/smlx/jiratime/internal/parse"
+)
+
+// getRoundTime returns the duration which needs to be added to bring the slice
+// of Worklogs up to a multiple of 15 minutes.
+func getRoundTime(worklogs []parse.Worklog) time.Duration {
+	// sum the worklogs durations
+	var total time.Duration
+	for _, worklog := range worklogs {
+		total += worklog.Duration
+	}
+	// mod 15 minutes
+	mod15 := total % (15 * time.Minute)
+	// if not zero, subtract from 15 minutes
+	if mod15 > 0 {
+		return (15 * time.Minute) - mod15
+	}
+	return 0
+}
+
+// RoundWorklogs takes a map of parsed worklogs and returns an updated map with
+// the total worklogs of matching issues rounded up to the next 15 minutes.
+//
+// This is done by adding a worklog entry for the issue to round out the total.
+func RoundWorklogs(worklogs map[string][]parse.Worklog,
+	roundIssues []config.Regexp) {
+	for issueKey := range worklogs {
+		for _, roundIssue := range roundIssues {
+			if roundIssue.MatchString(issueKey) {
+				roundTime := getRoundTime(worklogs[issueKey])
+				if roundTime > 0 {
+					// add a rounding issue to the issue worklogs
+					now := time.Now()
+					worklogs[issueKey] = append(worklogs[issueKey],
+						parse.Worklog{
+							Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+								0, now.Location()),
+							Duration: roundTime,
+							Comment:  "round to 15 minutes",
+						})
+				}
+				break // go to the next issueKey
+			}
+		}
+	}
+}

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -1,0 +1,577 @@
+package process
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/smlx/jiratime/internal/config"
+	"github.com/smlx/jiratime/internal/parse"
+)
+
+func TestGetRoundTime(t *testing.T) {
+	var testCases = map[string]struct {
+		input  []parse.Worklog
+		expect time.Duration
+	}{
+		"nil slice": {
+			input:  nil,
+			expect: 0,
+		},
+		"nothing logged": {
+			input:  []parse.Worklog{},
+			expect: 0,
+		},
+		"less than 15 min logged in a single entry": {
+			input: []parse.Worklog{
+				{Duration: 5 * time.Minute},
+			},
+			expect: 10 * time.Minute,
+		},
+		"less than 15 min logged in multiple entries": {
+			input: []parse.Worklog{
+				{Duration: 5 * time.Minute},
+				{Duration: 5 * time.Minute},
+			},
+			expect: 5 * time.Minute,
+		},
+		"multiple of 15 min logged in single entry": {
+			input: []parse.Worklog{
+				{Duration: 15 * time.Minute},
+			},
+			expect: 0,
+		},
+		"multiple of 15 min logged in multiple entries 1": {
+			input: []parse.Worklog{
+				{Duration: 5 * time.Minute},
+				{Duration: 10 * time.Minute},
+			},
+			expect: 0,
+		},
+		"multiple of 15 min logged in multiple entries 2": {
+			input: []parse.Worklog{
+				{Duration: 5 * time.Minute},
+				{Duration: 5 * time.Minute},
+				{Duration: 5 * time.Minute},
+			},
+			expect: 0,
+		},
+		"more than 15 min logged in single entry": {
+			input: []parse.Worklog{
+				{Duration: 40 * time.Minute},
+			},
+			expect: 5 * time.Minute,
+		},
+		"more than 15 min logged in multiple entries": {
+			input: []parse.Worklog{
+				{Duration: 5 * time.Minute},
+				{Duration: 5 * time.Minute},
+				{Duration: 75 * time.Minute},
+			},
+			expect: 5 * time.Minute,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(tt *testing.T) {
+			assert.Equal(tt, tc.expect, getRoundTime(tc.input), "getRoundTime")
+		})
+	}
+}
+
+func TestRoundWorklogs(t *testing.T) {
+	now := time.Now()
+	type roundWorklogsInput struct {
+		worklogs    map[string][]parse.Worklog
+		roundIssues []config.Regexp
+	}
+	var testCases = map[string]struct {
+		input  roundWorklogsInput
+		expect map[string][]parse.Worklog
+	}{
+		"nil worklogs": {
+			input: roundWorklogsInput{
+				worklogs: nil,
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			}, expect: nil,
+		},
+		"empty worklogs": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			}, expect: map[string][]parse.Worklog{},
+		},
+		"nil roundIssues": {
+			input: roundWorklogsInput{
+				worklogs:    map[string][]parse.Worklog{},
+				roundIssues: nil,
+			}, expect: map[string][]parse.Worklog{},
+		},
+		"empty roundIssues": {
+			input: roundWorklogsInput{
+				worklogs:    map[string][]parse.Worklog{},
+				roundIssues: []config.Regexp{},
+			}, expect: map[string][]parse.Worklog{},
+		},
+		"single issue, match, no rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"FOO-12": {
+						{Duration: 15 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"FOO-12": {
+					{Duration: 15 * time.Minute},
+				},
+			},
+		},
+		"single issue, match, rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"FOO-12": {
+						{Duration: 20 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"FOO-12": {
+					{Duration: 20 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 10 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+			},
+		},
+		"single issue, no match": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"ABC-4": {
+						{Duration: 20 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"ABC-4": {
+					{Duration: 20 * time.Minute},
+				},
+			},
+		},
+		"multiple issues, single match, rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"ABC-4": {
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-66": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"ABC-4": {
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-66": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 5 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+			},
+		},
+		"multiple issues, single match, no rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"ABC-4": {
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-86": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"ABC-4": {
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-86": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+			},
+		},
+		"multiple issues, multiple match, some rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"ABC-4": {
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-86": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-96": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 5 * time.Minute},
+					},
+					"FOO-92": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-56": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 40 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"ABC-4": {
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-86": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-96": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 5 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 10 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+				"FOO-92": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-56": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 40 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 5 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+			},
+		},
+		"multiple issues, multiple match, no rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"ABC-4": {
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-86": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-96": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-92": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 15 * time.Minute},
+					},
+					"FOO-56": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 45 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"ABC-4": {
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-86": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-96": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-92": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 15 * time.Minute},
+				},
+				"FOO-56": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 45 * time.Minute},
+				},
+			},
+		},
+		"multiple issues, all match, some rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"FOO-86": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-96": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 10 * time.Minute},
+					},
+					"FOO-92": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 10 * time.Minute},
+					},
+					"FOO-56": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 45 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"FOO-86": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-96": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 10 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 10 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+				"FOO-92": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 10 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 5 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+				"FOO-56": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 45 * time.Minute},
+				},
+			},
+		},
+		"multiple issues, all match, all rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"FOO-86": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 15 * time.Minute},
+					},
+					"FOO-96": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 10 * time.Minute},
+					},
+					"FOO-92": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 10 * time.Minute},
+					},
+					"FOO-56": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 40 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"FOO-86": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 15 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 5 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+				"FOO-96": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 10 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 10 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+				"FOO-92": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 10 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 5 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+				"FOO-56": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 40 * time.Minute},
+					{
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							0, now.Location()),
+						Duration: 5 * time.Minute,
+						Comment:  "round to 15 minutes",
+					},
+				},
+			},
+		},
+		"multiple issues, all match, no rounding": {
+			input: roundWorklogsInput{
+				worklogs: map[string][]parse.Worklog{
+					"FOO-86": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 15 * time.Minute},
+						{Duration: 5 * time.Minute},
+					},
+					"FOO-96": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 5 * time.Minute},
+					},
+					"FOO-92": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+					},
+					"FOO-56": {
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 20 * time.Minute},
+						{Duration: 30 * time.Minute},
+					},
+				},
+				roundIssues: []config.Regexp{
+					{Regexp: *regexp.MustCompile("^FOO-")},
+				},
+			},
+			expect: map[string][]parse.Worklog{
+				"FOO-86": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 15 * time.Minute},
+					{Duration: 5 * time.Minute},
+				},
+				"FOO-96": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 5 * time.Minute},
+				},
+				"FOO-92": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+				},
+				"FOO-56": {
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 20 * time.Minute},
+					{Duration: 30 * time.Minute},
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(tt *testing.T) {
+			RoundWorklogs(tc.input.worklogs, tc.input.roundIssues)
+			assert.Equal(tt, tc.expect, tc.input.worklogs, "RoundWorklogs")
+		})
+	}
+}


### PR DESCRIPTION
For organisational reasons, lower precision is sometimes desirable for worklogs.

This changes adds the option to lower the precision to 0.25 hours for selected JIRA issues.