### PR TITLE
fix: use midday for rounding worklogs

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -40,7 +40,7 @@ func RoundWorklogs(worklogs map[string][]parse.Worklog,
 					now := time.Now()
 					worklogs[issueKey] = append(worklogs[issueKey],
 						parse.Worklog{
-							Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+							Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 								0, now.Location()),
 							Duration: roundTime,
 							Comment:  "round to 15 minutes",

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -149,7 +149,7 @@ func TestRoundWorklogs(t *testing.T) {
 				"FOO-12": {
 					{Duration: 20 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 10 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -197,7 +197,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 20 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 5 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -280,7 +280,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 5 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 10 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -297,7 +297,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 40 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 5 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -407,7 +407,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 10 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 10 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -419,7 +419,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 10 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 5 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -469,7 +469,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 15 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 5 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -480,7 +480,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 10 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 10 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -492,7 +492,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 10 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 5 * time.Minute,
 						Comment:  "round to 15 minutes",
@@ -504,7 +504,7 @@ func TestRoundWorklogs(t *testing.T) {
 					{Duration: 20 * time.Minute},
 					{Duration: 40 * time.Minute},
 					{
-						Started: time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0,
+						Started: time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0,
 							0, now.Location()),
 						Duration: 5 * time.Minute,
 						Comment:  "round to 15 minutes",


### PR DESCRIPTION
This makes Tempo display the rounding worklogs correctly for a wider array of timezones.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
